### PR TITLE
Add role for matrix-synapse (includes element-web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # AlmaLinux Infrastructure Ansible Playbooks
 
 ansible-galaxy install -r requirements.yml
+
+dnf install python3-hvac
+
+OR
+
+python3 -m pip install hvac

--- a/group_vars/matrix_synapse.yml
+++ b/group_vars/matrix_synapse.yml
@@ -1,0 +1,4 @@
+---
+matrix_synapse_python_version: 3.12
+matrix_synapse_version: 1.109
+matrix_synapse_element_version: 1.11.68

--- a/group_vars/matrix_synapse_stg.yml
+++ b/group_vars/matrix_synapse_stg.yml
@@ -1,0 +1,5 @@
+---
+matrix_synapse_staging: true
+matrix_synapse_python_version: 3.12
+matrix_synapse_version: 1.109
+matrix_synapse_element_version: 1.11.68

--- a/host_vars/almalinux.im.yml
+++ b/host_vars/almalinux.im.yml
@@ -1,0 +1,119 @@
+---
+matrix_synapse_config_server_name: "{% if matrix_synapse_staging %}stg.{% endif %}almalinux.im"
+matrix_synapse_config_app_server_name: app.{% if matrix_synapse_staging %}stg.{% endif %}almalinux.im
+
+hashi_vault_path: "kv/data/infra/{% if matrix_synapse_staging %}stg/{% endif %}synapse"
+
+matrix_synapse_signing_key: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:signing_key',
+        token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+
+firewalld_extra_allow_ports:
+  - "8448/tcp"
+  - "8448/udp"
+
+postgresql_databases:
+  - name: synapse
+    lc_collate: C
+    lc_ctype: C
+
+postgresql_users:
+  - name: synapse_user
+    password: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:database_password',
+        token=lookup('env', 'VAULT_TOKEN'), url=secrets_url) }}"
+    db: synapse
+
+# synapse config
+matrix_synapse_homeserver_config:
+  server_name: "{{ matrix_synapse_config_server_name }}"
+  pid_file: "{{ matrix_synapse_config_pid_file | default('/var/run/synapse.pid') }}"
+  listeners:
+    - port: 8008
+      tls: false
+      type: http
+      x_forwarded: true
+      bind_addresses: ['::1', '127.0.0.1']
+      resources:
+        - names: [client, federation]
+          compress: false
+  database:
+    name: psycopg2
+    args:
+      user: synapse_user
+      password: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:database_password',
+        token=lookup('env', 'VAULT_TOKEN'), url=secrets_url) }}"
+      dbname: synapse
+      host: localhost
+      cp_min: 5
+      cp_max: 10
+  log_config: "/etc/synapse/{{ matrix_synapse_config_server_name }}.log.config"
+  media_store_path: "{{ matrix_synapse_config_media_store_path | default('/var/lib/synapse/media_store') }}"
+  registration_shared_secret: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:registration_shared_secret',
+        token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+  report_stats: "{{ matrix_synapse_config_report_stats | default('true') }}"
+  macaroon_secret_key: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:macaroon_secret_key',
+        token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+  form_secret: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:form_secret',
+        token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+  signing_key_path: "/etc/synapse/{{ matrix_synapse_config_server_name }}.signing.key"
+  trusted_key_servers:
+    - server_name: "matrix.org"
+  password_config:
+    enabled: only_for_reauth
+  oidc_providers:
+    - idp_id: keycloak
+      idp_name: "id.almalinux.org"
+      issuer: "https://id.almalinux.org/realms/master"
+      client_id: "synapse"
+      client_secret: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:oidc_client_secret',
+        token=lookup('env', 'VAULT_TOKEN'), url=secrets_url) }}"
+      scopes: ["openid", "profile"]
+      user_mapping_provider:
+        config:
+          localpart_template: "{% raw %}{{ user.preferred_username }}{% endraw %}"
+          display_name_template: "{% raw %}{{ user.name }}{% endraw %}"
+      backchannel_logout_enabled: true # Optional
+  auto_join_rooms:
+    - "#general:{% if matrix_synapse_staging %}stg.{% endif %}almalinux.im"
+  # Allow specific users to publish rooms, deny otehrs
+  room_list_publication_rules:
+    - user_id: "@jonathan:{% if matrix_synapse_staging %}stg.{% endif %}almalinux.im"
+      action: allow
+    - action: deny
+
+# element-web config
+matrix_synapse_element_config:
+  default_server_config:
+    m.homeserver:
+      base_url: 'https://{{ matrix_synapse_config_server_name }}'
+      server_name: '{{ matrix_synapse_config_server_name }}'
+  disable_custom_urls: true
+  disable_guests: false
+  disable_login_language_selector: false
+  disable_3pid_login: true
+  brand: AlmaLinux Element
+  integrations_ui_url: 'https://scalar.vector.im/'
+  integrations_rest_url: 'https://scalar.vector.im/api'
+  integrations_widgets_urls:
+    - 'https://scalar.vector.im/_matrix/integrations/v1'
+    - 'https://scalar.vector.im/api'
+    - 'https://scalar-staging.vector.im/_matrix/integrations/v1'
+    - 'https://scalar-staging.vector.im/api'
+    - 'https://scalar-staging.riot.im/scalar/api'
+  default_country_code: US
+  show_labs_settings: false
+  features: {}
+  default_federate: true
+  default_theme: dark
+  room_directory:
+    servers:
+      - '{{ matrix_synapse_config_server_name }}'
+  enable_presence_by_hs_url:
+    'https://matrix.org': false
+    'https://matrix-client.matrix.org': false
+  setting_defaults:
+    breadcrumbs: true
+  jitsi:
+    preferred_domain: meet.almalinux.org
+  map_style_url: 'https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx'
+  branding:
+    auth_header_logo_url: 'https://almalinux.org/images/icon.svg'

--- a/host_vars/stg.almalinux.im.yml
+++ b/host_vars/stg.almalinux.im.yml
@@ -1,0 +1,119 @@
+---
+matrix_synapse_config_server_name: "{% if matrix_synapse_staging %}stg.{% endif %}almalinux.im"
+matrix_synapse_config_app_server_name: app.{% if matrix_synapse_staging %}stg.{% endif %}almalinux.im
+
+hashi_vault_path: "kv/data/infra/{% if matrix_synapse_staging %}stg/{% endif %}synapse"
+
+matrix_synapse_signing_key: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:signing_key',
+        token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+
+firewalld_extra_allow_ports:
+  - "8448/tcp"
+  - "8448/udp"
+
+postgresql_databases:
+  - name: synapse
+    lc_collate: C
+    lc_ctype: C
+
+postgresql_users:
+  - name: synapse_user
+    password: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:database_password',
+        token=lookup('env', 'VAULT_TOKEN'), url=secrets_url) }}"
+    db: synapse
+
+# synapse config
+matrix_synapse_homeserver_config:
+  server_name: "{{ matrix_synapse_config_server_name }}"
+  pid_file: "{{ matrix_synapse_config_pid_file | default('/var/run/synapse.pid') }}"
+  listeners:
+    - port: 8008
+      tls: false
+      type: http
+      x_forwarded: true
+      bind_addresses: ['::1', '127.0.0.1']
+      resources:
+        - names: [client, federation]
+          compress: false
+  database:
+    name: psycopg2
+    args:
+      user: synapse_user
+      password: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:database_password',
+        token=lookup('env', 'VAULT_TOKEN'), url=secrets_url) }}"
+      dbname: synapse
+      host: localhost
+      cp_min: 5
+      cp_max: 10
+  log_config: "/etc/synapse/{{ matrix_synapse_config_server_name }}.log.config"
+  media_store_path: "{{ matrix_synapse_config_media_store_path | default('/var/lib/synapse/media_store') }}"
+  registration_shared_secret: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:registration_shared_secret',
+        token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+  report_stats: "{{ matrix_synapse_config_report_stats | default('true') }}"
+  macaroon_secret_key: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:macaroon_secret_key',
+        token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+  form_secret: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:form_secret',
+        token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+  signing_key_path: "/etc/synapse/{{ matrix_synapse_config_server_name }}.signing.key"
+  trusted_key_servers:
+    - server_name: "matrix.org"
+  password_config:
+    enabled: only_for_reauth
+  oidc_providers:
+    - idp_id: keycloak
+      idp_name: "id.almalinux.org"
+      issuer: "https://id.almalinux.org/realms/master"
+      client_id: "synapse"
+      client_secret: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:oidc_client_secret',
+        token=lookup('env', 'VAULT_TOKEN'), url=secrets_url) }}"
+      scopes: ["openid", "profile"]
+      user_mapping_provider:
+        config:
+          localpart_template: "{% raw %}{{ user.preferred_username }}{% endraw %}"
+          display_name_template: "{% raw %}{{ user.name }}{% endraw %}"
+      backchannel_logout_enabled: true # Optional
+  auto_join_rooms:
+    - "#general:{% if matrix_synapse_staging %}stg.{% endif %}almalinux.im"
+  # Allow specific users to publish rooms, deny otehrs
+  room_list_publication_rules:
+    - user_id: "@jonathan:{% if matrix_synapse_staging %}stg.{% endif %}almalinux.im"
+      action: allow
+    - action: deny
+
+# element-web config
+matrix_synapse_element_config:
+  default_server_config:
+    m.homeserver:
+      base_url: 'https://{{ matrix_synapse_config_server_name }}'
+      server_name: '{{ matrix_synapse_config_server_name }}'
+  disable_custom_urls: true
+  disable_guests: false
+  disable_login_language_selector: false
+  disable_3pid_login: true
+  brand: AlmaLinux Element
+  integrations_ui_url: 'https://scalar.vector.im/'
+  integrations_rest_url: 'https://scalar.vector.im/api'
+  integrations_widgets_urls:
+    - 'https://scalar.vector.im/_matrix/integrations/v1'
+    - 'https://scalar.vector.im/api'
+    - 'https://scalar-staging.vector.im/_matrix/integrations/v1'
+    - 'https://scalar-staging.vector.im/api'
+    - 'https://scalar-staging.riot.im/scalar/api'
+  default_country_code: US
+  show_labs_settings: false
+  features: {}
+  default_federate: true
+  default_theme: dark
+  room_directory:
+    servers:
+      - '{{ matrix_synapse_config_server_name }}'
+  enable_presence_by_hs_url:
+    'https://matrix.org': false
+    'https://matrix-client.matrix.org': false
+  setting_defaults:
+    breadcrumbs: true
+  jitsi:
+    preferred_domain: meet.almalinux.org
+  map_style_url: 'https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx'
+  branding:
+    auth_header_logo_url: 'https://almalinux.org/images/icon.svg'

--- a/hosts
+++ b/hosts
@@ -27,6 +27,12 @@
 [external_managed_mirrors]
 almalinux-mirror.yucca.net
 
+[matrix_synapse]
+almalinux.im ansible_host=170.249.201.58
+
+[matrix_synapse_stg]
+stg.almalinux.im
+
 [mirrors:children]
 aws_mirrors
 azure_mirrors

--- a/matrix_synapse.yml
+++ b/matrix_synapse.yml
@@ -1,0 +1,13 @@
+---
+- name: Configure matrix-synapse servers
+  hosts:
+    - matrix_synapse
+    - matrix_synapse_stg
+  roles:
+    - common
+    - role: geerlingguy.postgresql
+      when: matrix_synapse_configure_local_db
+    - matrix_synapse
+    - community.zabbix.zabbix_agent
+    - devsec.hardening.os_hardening
+    - devsec.hardening.ssh_hardening

--- a/requirements.yml
+++ b/requirements.yml
@@ -11,3 +11,4 @@ roles:
     - name: artis3n.tailscale
     - name: ansible-modules-hashivault
       src: git+https://github.com/TerryHowe/ansible-modules-hashivault.git
+    - name: geerlingguy.postgresql

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,0 +1,1 @@
+whitelist_ips: [] # noqa var-naming[no-role-prefix]

--- a/roles/matrix_synapse/README.md
+++ b/roles/matrix_synapse/README.md
@@ -1,0 +1,1 @@
+This role supports AlmaLinux/RHEL 9 and greater.

--- a/roles/matrix_synapse/defaults/main.yml
+++ b/roles/matrix_synapse/defaults/main.yml
@@ -1,0 +1,76 @@
+---
+matrix_synapse_install_method: pip
+matrix_synapse_python_version: "3"
+matrix_synapse_python_package_name: python{{ matrix_synapse_python_version }}
+matrix_synapse_pip_package_name: "{{ matrix_synapse_python_package_name }}-pip"
+matrix_synapse_venv_path: /opt/matrix_synapse_venv
+matrix_synapse_configure_local_db: true
+matrix_synapse_configure_caddy: true
+matrix_synapse_install_element: true
+matrix_synapse_element_auth_header_logo_url: false
+
+# element-web config
+matrix_synapse_element_config:
+  default_server_config:
+    m.homeserver:
+      base_url: 'https://matrix-client.matrix.org'
+      server_name: matrix.org
+    m.identity_server:
+      base_url: 'https://vector.im'
+  disable_custom_urls: false
+  disable_guests: false
+  disable_login_language_selector: false
+  disable_3pid_login: false
+  brand: Element
+  integrations_ui_url: 'https://scalar.vector.im/'
+  integrations_rest_url: 'https://scalar.vector.im/api'
+  integrations_widgets_urls:
+    - 'https://scalar.vector.im/_matrix/integrations/v1'
+    - 'https://scalar.vector.im/api'
+    - 'https://scalar-staging.vector.im/_matrix/integrations/v1'
+    - 'https://scalar-staging.vector.im/api'
+    - 'https://scalar-staging.riot.im/scalar/api'
+  default_country_code: US
+  show_labs_settings: false
+  features: {}
+  default_federate: true
+  default_theme: light
+  room_directory:
+    servers:
+      - matrix.org
+  enable_presence_by_hs_url:
+    'https://matrix.org': false
+    'https://matrix-client.matrix.org': false
+  setting_defaults:
+    breadcrumbs: true
+  jitsi:
+    preferred_domain: meet.element.io
+  element_call:
+    url: 'https://call.element.io'
+    participant_limit: 8
+    brand: Element Call
+  map_style_url: 'https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx'
+
+# matrix-synapse config
+matrix_synapse_homeserver_config:
+  server_name: "{{ matrix_synapse_config_server_name }}"
+  pid_file: /var/run/synapse.pid
+  listeners:
+    - port: 8008
+      tls: false
+      type: http
+      x_forwarded: true
+      bind_addresses: ['::1', '127.0.0.1']
+      resources:
+        - names: [client, federation]
+          compress: false
+  database:
+    name: sqlite3
+    args:
+      database: /var/lib/synapse/homeserver.db
+  report_stats: true
+  log_config: "/etc/synapse/{{ matrix_synapse_config_server_name }}.log.config"
+  media_store_path: /var/lib/synapse/media_store
+  signing_key_path: "/etc/synapse/{{ matrix_synapse_config_server_name }}.signing.key"
+  trusted_key_servers:
+    - server_name: "matrix.org"

--- a/roles/matrix_synapse/defaults/main.yml
+++ b/roles/matrix_synapse/defaults/main.yml
@@ -8,6 +8,9 @@ matrix_synapse_configure_local_db: true
 matrix_synapse_configure_caddy: true
 matrix_synapse_install_element: true
 matrix_synapse_element_auth_header_logo_url: false
+matrix_synapse_staging: false
+matrix_synapse_config_server_name: "{% if matrix_synapse_staging %}stg.{% endif %}example.tld"
+matrix_synapse_config_app_server_name: app.{% if matrix_synapse_staging %}stg.{% endif %}example.tld
 
 # element-web config
 matrix_synapse_element_config:

--- a/roles/matrix_synapse/handlers/main.yml
+++ b/roles/matrix_synapse/handlers/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Reload matrix-synapse
+  ansible.builtin.systemd:
+    name: matrix-synapse
+    state: reloaded
+
+- name: Restart matrix-synapse
+  ansible.builtin.systemd:
+    name: matrix-synapse
+    state: restarted
+
+- name: Restart caddy
+  ansible.builtin.systemd:
+    name: caddy.service
+    state: restarted

--- a/roles/matrix_synapse/tasks/caddy.yml
+++ b/roles/matrix_synapse/tasks/caddy.yml
@@ -36,3 +36,11 @@
   loop:
     - tcp
     - udp
+
+- name: Start and enable Caddy
+  ansible.builtin.systemd:
+    name: caddy.service
+    state: started
+    enabled: true
+  tags:
+    - caddy

--- a/roles/matrix_synapse/tasks/caddy.yml
+++ b/roles/matrix_synapse/tasks/caddy.yml
@@ -1,0 +1,38 @@
+---
+- name: Install Caddy
+  ansible.builtin.dnf:
+    name: caddy
+    state: present
+  tags:
+    - caddy
+
+- name: Create Caddy log dir
+  ansible.builtin.file:
+    path: /var/log/caddy/
+    owner: caddy
+    group: caddy
+    mode: "0700"
+    state: directory
+  tags:
+    - caddy
+
+- name: Distribute /etc/caddy/Caddyfile
+  ansible.builtin.template:
+    src: Caddyfile.j2
+    dest: /etc/caddy/Caddyfile
+    mode: "0600"
+    owner: caddy
+    group: caddy
+  notify: Restart caddy
+  tags:
+    - caddy
+
+- name: Allow binding ports in selinux
+  community.general.seport:
+    ports: 8448
+    proto: "{{ item }}"
+    setype: http_port_t
+    state: present
+  loop:
+    - tcp
+    - udp

--- a/roles/matrix_synapse/tasks/element.yml
+++ b/roles/matrix_synapse/tasks/element.yml
@@ -1,0 +1,21 @@
+---
+# TODO: package this for epel or copr
+- name: Download element-web release archive {{ matrix_synapse_element_version }}
+  ansible.builtin.get_url:
+    url: https://github.com/element-hq/element-web/releases/download/v{{ matrix_synapse_element_version }}/element-v{{ matrix_synapse_element_version }}.tar.gz
+    dest: /tmp/element-v{{ matrix_synapse_element_version }}.tar.gz
+    mode: "0644"
+
+- name: Extract element-web archive
+  ansible.builtin.unarchive:
+    src: /tmp/element-v{{ matrix_synapse_element_version }}.tar.gz
+    dest: /usr/share/caddy/
+    remote_src: true
+
+- name: Write config file
+  ansible.builtin.template:
+    src: element.config.json.j2
+    dest: /usr/share/caddy/element-v{{ matrix_synapse_element_version }}/config.json
+    mode: "0644"
+    owner: caddy
+    group: caddy

--- a/roles/matrix_synapse/tasks/main.yml
+++ b/roles/matrix_synapse/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Include tasks for installing with pip
+  ansible.builtin.include_tasks: pip.yml
+  when: matrix_synapse_install_method == "pip"
+
+- name: Configure caddy reverse proxy
+  ansible.builtin.include_tasks: caddy.yml
+  when: matrix_synapse_configure_local_db
+
+- name: Configure element web app
+  ansible.builtin.include_tasks: element.yml
+  when: matrix_synapse_install_element

--- a/roles/matrix_synapse/tasks/pip.yml
+++ b/roles/matrix_synapse/tasks/pip.yml
@@ -1,0 +1,83 @@
+---
+- name: Install dependencies
+  ansible.builtin.package:
+    name:
+      - gcc
+      - libpq-devel
+      - python{{ matrix_synapse_python_version }}-devel
+
+- name: Install python/pip {{ matrix_synapse_python_version }}
+  ansible.builtin.package:
+    name:
+      - "{{ matrix_synapse_python_package_name }}"
+      - "{{ matrix_synapse_pip_package_name }}"
+
+- name: Install matrix-synapse
+  ansible.builtin.pip:
+    virtualenv_command: "{{ matrix_synapse_python_package_name }} -m venv"
+    virtualenv: "{{ matrix_synapse_venv_path }}"
+    name:
+      - matrix-synapse == {{ matrix_synapse_version }}
+      - matrix-synapse[oidc] == {{ matrix_synapse_version }}
+      - matrix-synapse[postgres] == {{ matrix_synapse_version }}
+    umask: "0022"
+  notify: Restart matrix-synapse
+
+- name: Install sytemd service
+  ansible.builtin.template:
+    src: matrix-synapse.service.j2
+    dest: /etc/systemd/system/matrix-synapse.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Reload systemd
+    - Reload matrix-synapse
+
+- name: Create synapse system user
+  ansible.builtin.user:
+    name: synapse
+    create_home: false
+
+- name: Create config dir
+  ansible.builtin.file:
+    path: /etc/synapse
+    state: directory
+    owner: synapse
+    group: synapse
+    mode: "0700"
+
+- name: Create working dir
+  ansible.builtin.file:
+    path: /var/lib/synapse
+    state: directory
+    owner: synapse
+    group: synapse
+    mode: "0700"
+
+- name: Write config
+  ansible.builtin.template:
+    src: homeserver.yaml.j2
+    dest: /etc/synapse/homeserver.yaml
+    owner: synapse
+    group: synapse
+    mode: "0600"
+  notify:
+    - Reload matrix-synapse
+
+- name: Write signing key
+  ansible.builtin.copy:
+    content: "{{ matrix_synapse_signing_key }}"
+    dest: /etc/synapse/{{ matrix_synapse_config_server_name }}.signing.key
+    owner: synapse
+    group: synapse
+    mode: "0600"
+  when: matrix_synapse_signing_key is defined
+  notify:
+    - Reload matrix-synapse
+
+- name: Enable and start matrix-synapse
+  ansible.builtin.systemd:
+    name: matrix-synapse
+    enabled: true
+    state: started

--- a/roles/matrix_synapse/templates/Caddyfile.j2
+++ b/roles/matrix_synapse/templates/Caddyfile.j2
@@ -1,0 +1,52 @@
+# {{ ansible_managed }}
+
+{{ matrix_synapse_config_server_name }} {
+  header /.well-known/matrix/* Content-Type application/json
+  header /.well-known/matrix/* Access-Control-Allow-Origin *
+  respond /.well-known/matrix/server `{"m.server": "{{ matrix_synapse_config_server_name }}:443"}`
+  respond /.well-known/matrix/client `{"m.homeserver":{"base_url":"https://{{ matrix_synapse_config_server_name }}","server_name":"{{ matrix_synapse_config_server_name }}"}}`
+
+  reverse_proxy /_matrix/* localhost:8008
+  reverse_proxy /_synapse/* localhost:8008
+  reverse_proxy /_synapse/client/* localhost:8008
+  #reverse_proxy /synapse-admin* localhost:8080
+  handle_path /synapse-admin* {
+    reverse_proxy localhost:8080
+  }
+
+  log {
+    output file /var/log/caddy/{{ matrix_synapse_config_server_name }}.access.log {
+      roll_keep_for 30d
+    }
+  }
+}
+
+{{ matrix_synapse_config_server_name }}:8448 {
+  reverse_proxy /_matrix/* localhost:8008
+}
+
+{% if matrix_synapse_install_element %}
+{{ matrix_synapse_config_app_server_name }} {
+  root * /usr/share/caddy/element-v{{ matrix_synapse_element_version }}
+  file_server {
+    hide .git
+  }
+
+  encode * {
+    gzip 6
+    zstd
+  }
+
+  @static {
+    file
+    path *.ico *.css *.js *.gif *.jpg *.jpeg *.png *.svg *.woff *.woff2 *.ogg
+  }
+  header @static Cache-Control max-age=5184000
+
+  log {
+    output file /var/log/caddy/{{ matrix_synapse_config_app_server_name }}.access.log {
+      roll_keep_for 30d
+    }
+  }
+}
+{% endif %}

--- a/roles/matrix_synapse/templates/element.config.json.j2
+++ b/roles/matrix_synapse/templates/element.config.json.j2
@@ -1,0 +1,1 @@
+{{ matrix_synapse_element_config | to_nice_json }}

--- a/roles/matrix_synapse/templates/homeserver.yaml.j2
+++ b/roles/matrix_synapse/templates/homeserver.yaml.j2
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+# Configuration file for Synapse.
+#
+# This is a YAML file: see [1] for a quick introduction. Note in particular
+# that *indentation is important*: all the elements of a list or dictionary
+# should have the same indentation.
+#
+# [1] https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html
+#
+# For more information on how to configure Synapse, including a complete accounting of
+# each option, go to docs/usage/configuration/config_documentation.md or
+# https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html
+
+{{ matrix_synapse_homeserver_config | to_nice_yaml(indent=2, sort_keys=false) }}
+
+# vim:ft=yaml

--- a/roles/matrix_synapse/templates/matrix-synapse.service.j2
+++ b/roles/matrix_synapse/templates/matrix-synapse.service.j2
@@ -1,0 +1,19 @@
+# {{ ansible_managed }}
+# original source from https://src.fedoraproject.org/rpms/matrix-synapse/blob/66ba92113721233301eb569974e7bd71812b417b/f/synapse.service
+[Unit]
+Description=Synapse Matrix homeserver
+After=network-online.target postgresql.service
+
+[Service]
+Type=notify
+NotifyAccess=main
+User=synapse
+Group=synapse
+WorkingDirectory=/var/lib/synapse
+ExecStart={% if matrix_synapse_install_method == "pip" %}{{ matrix_synapse_venv_path }}/bin/{% else %}/usr/bin/{% endif %}python{{ matrix_synapse_python_version }} -m synapse.app.homeserver --config-path=/etc/synapse/homeserver.yaml
+ExecReload=/bin/kill -HUP $MAINPID
+# EnvironmentFile=-/etc/sysconfig/synapse  # Can be used to e.g. set SYNAPSE_CACHE_FACTOR
+SyslogIdentifier=synapse
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
fixes #4

First draft.

TODO:
- [x] Finish templating element-web config with proper variables.  Perhaps store in pure yaml (group/host vars) and convert to json.
- [x] Include defaults for setting up a minimal environment
- [x] Add permanent dev/testing host
- [x] Configure firewalld/open ports (8448 not open, but do we still need that?)
- [x] Ensure compatibility with fedora (if feasible) and EL 8/9