### PR TITLE
ignore external roles when linting

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Run ansible-lint
         shell: bash
         working-directory: ${{ github.workspace }}
-        run: ansible-lint --offline
+        run: ansible-lint --exclude ${HOME}/.ansible/roles/ --offline


### PR DESCRIPTION
We don't want to fail lint on our code due to external dependencies/roles/collections that we're pulling in from git/galaxy.