### PR TITLE
Add and adjust default webhook timeout from 5s -> 300s

### DIFF
--- a/group_vars/gitea.yml
+++ b/group_vars/gitea.yml
@@ -127,3 +127,5 @@ gitea_config:
       ENABLED: "true"
       SHCEDULE: "@midnight"
       OLDER_THAN: 24h
+    webhook:
+      DELIVER_TIMEOUT: 300


### PR DESCRIPTION
- Requested by Stepan for pungi webhook