### PR TITLE
run ansible-lint through venv

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 env:
-  ansible_lint_version: v24.5.0
+  # ansible_lint_version: v24.5.0
   python_version: 3.12 # must have an alma rpm available in format python<version>
 
 jobs:
@@ -19,25 +19,29 @@ jobs:
       - name: Install dnf dependencies
         shell: bash
         run: |
-          dnf -y install ansible-core epel-release git-core python3.12 python3.12-pip
+          dnf -y install ansible-core epel-release git-core python$python_version python$python_version-pip
 
-      - name: Install ansible and ansible-lint
+      - name: Create and enter venv
+        shell: bash
+        run: |
+          python$python_version -m venv /venv
+
+      - name: Install ansible-lint
         shell: bash
         # if we need to version lock example:
         # pip3.12 install "ansible-lint[lock] @ git+https://github.com/ansible/ansible-lint@$ansible_lint_version"
         run: |
-          pip$python_version install "ansible"
-          pip$python_version install "ansible-lint[lock]"
-          ansible-lint --version
+          /venv/bin/pip install "ansible-lint"
+          /venv/bin/ansible-lint --version
 
       # for some reason ansible-lint in online mode does not grab all deps properly
       # this does
       - name: Install ansible-galaxy dependencies
         shell: bash
         run: |
-          ansible-galaxy install -r requirements.yml
+          /venv/bin/ansible-galaxy install -r requirements.yml
 
       - name: Run ansible-lint
         shell: bash
         working-directory: ${{ github.workspace }}
-        run: ansible-lint --exclude ${HOME}/.ansible/roles/ --offline
+        run: /venv/bin/ansible-lint --exclude ${HOME}/.ansible/roles/ --exclude ${HOME}/.ansible/collections/ --offline


### PR DESCRIPTION
This changes ansible-lint to running in a venv.  Running it as root was pulling in stock python/ansible collections/roles installed on the system which we do not want to lint against.