### PR TITLE
Adds keycloak role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode/
+tmp/
+keycloak-*.zip

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -21,6 +21,7 @@ common_packages:
   - nload
   # needed by many ansible roles that adjust selinux
   - python3-policycoreutils
+  - rsync
   - telnet
   - vim
   - yum-utils

--- a/group_vars/keycloak.yml
+++ b/group_vars/keycloak.yml
@@ -1,0 +1,65 @@
+---
+staging: false
+
+keycloak_certbot_ssl: true
+
+hashi_vault_path: "kv/data/infra/{% if staging %}stg/{% endif %}keycloak"
+
+firewalld_extra_allow_ports:
+  - "80/tcp"
+  - "443/tcp"
+
+sysctl_overwrite:
+  # Enable IPv4 traffic forwarding, needed for podman (mariadb galera cluster)
+  net.ipv4.ip_forward: 1
+
+keycloak_mariadb_version: 11.4
+keycloak_mariadb_user: keycloak
+keycloak_mariadb_password: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:keycloak_mariadb_password',
+  token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+keycloak_mariadb_database: keycloak
+keycloak_mariadb_galera_root_password: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:keycloak_mariadb_galera_root_password',
+  token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+keycloak_mariadb_galera_mariabackup_user: keycloak_mariabackup_user
+keycloak_mariadb_galera_mariabackup_password: "{{ lookup('community.hashi_vault.hashi_vault',
+  '{{ hashi_vault_path }}:keycloak_mariadb_galera_mariabackup_password',
+  token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+keycloak_mariadb_replication_user: keycloak_replication_user
+keycloak_mariadb_replication_password: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:keycloak_mariadb_replication_password',
+  token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+keycloak_mariadb_galera_cluster_address: gcomm://{% for ip in headscale_ips %}{{ ip }}:4567{{ ',' if not loop.last }}{% endfor %}
+keycloak_mariadb_extra_flags: --wsrep_provider_options=ist.recv_addr={{ headscale_address }}:4568;ist.recv_bind=0.0.0.0:4568
+  --wsrep_node_incoming_address={{ headscale_address }} --wsrep_sst_receive_address={{ headscale_address }}
+keycloak_mariadb_galera_ports:
+  - 127.0.0.1:3306:3306
+  - 4444:4444
+  - 4567:4567
+  - 4568:4568
+
+rhbk_enable: false
+keycloak_quarkus_ha_enabled: true
+keycloak_quarkus_db_enabled: true
+keycloak_quarkus_metrics_enabled: true
+keycloak_quarkus_db_engine: mariadb
+keycloak_quarkus_db_user: "{{ keycloak_mariadb_user }}"
+keycloak_quarkus_db_pass: "{{ keycloak_mariadb_password }}"
+keycloak_quarkus_bootstrap_admin_password: "{{ lookup('community.hashi_vault.hashi_vault',
+  '{{ hashi_vault_path }}:keycloak_quarkus_bootstrap_admin_password',
+  token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+keycloak_quarkus_version: 26.2.0
+keycloak_quarkus_jdbc_engine: mariadb
+keycloak_quarkus_hostname: id.almalinux.org
+keycloak_quarkus_health_check_url: http://localhost:{{ keycloak_quarkus_http_port }}/realms/master/.well-known/openid-configuration
+keycloak_quarkus_proxy_headers: xforwarded
+keycloak_quarkus_http_relative_path: /
+keycloak_quarkus_transaction_xa_enabled: false
+keycloak_quarkus_proxy_mode: edge
+keycloak_quarkus_java_opts: -Djgroups.external_addr={{ tailscale_address }} -Djgroups.bind.address={{ tailscale_address }}
+keycloak_quarkus_systemd_wait_for_port: false
+
+# run health checks against localhost since we are running a cluster
+keycloak_quarkus_dest: /opt/keycloak
+keycloak_quarkus_installdir: "{{ keycloak_quarkus_dest }}/keycloak-{{ keycloak_quarkus_version }}"
+keycloak_quarkus_home: "{{ keycloak_quarkus_installdir }}"
+keycloak_quarkus_config_dir: "{{ keycloak_quarkus_home }}/conf"
+# end health check config

--- a/group_vars/keycloak_stg.yml
+++ b/group_vars/keycloak_stg.yml
@@ -1,0 +1,65 @@
+---
+staging: true
+
+keycloak_certbot_ssl: true
+
+hashi_vault_path: "kv/data/infra/{% if staging %}stg/{% endif %}keycloak"
+
+firewalld_extra_allow_ports:
+  - "80/tcp"
+  - "443/tcp"
+
+sysctl_overwrite:
+  # Enable IPv4 traffic forwarding, needed for podman (mariadb galera cluster)
+  net.ipv4.ip_forward: 1
+
+keycloak_mariadb_version: 11.4
+keycloak_mariadb_user: keycloak
+keycloak_mariadb_password: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:keycloak_mariadb_password',
+  token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+keycloak_mariadb_database: keycloak
+keycloak_mariadb_galera_root_password: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:keycloak_mariadb_galera_root_password',
+  token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+keycloak_mariadb_galera_mariabackup_user: keycloak_mariabackup_user
+keycloak_mariadb_galera_mariabackup_password: "{{ lookup('community.hashi_vault.hashi_vault',
+  '{{ hashi_vault_path }}:keycloak_mariadb_galera_mariabackup_password',
+  token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+keycloak_mariadb_replication_user: keycloak_replication_user
+keycloak_mariadb_replication_password: "{{ lookup('community.hashi_vault.hashi_vault', '{{ hashi_vault_path }}:keycloak_mariadb_replication_password',
+  token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+keycloak_mariadb_galera_cluster_address: gcomm://{% for ip in headscale_ips %}{{ ip }}:4567{{ ',' if not loop.last }}{% endfor %}
+keycloak_mariadb_extra_flags: --wsrep_provider_options=ist.recv_addr={{ headscale_address }}:4568;ist.recv_bind=0.0.0.0:4568
+  --wsrep_node_incoming_address={{ headscale_address }} --wsrep_sst_receive_address={{ headscale_address }}
+keycloak_mariadb_galera_ports:
+  - 127.0.0.1:3306:3306
+  - 4444:4444
+  - 4567:4567
+  - 4568:4568
+
+rhbk_enable: false
+keycloak_quarkus_ha_enabled: true
+keycloak_quarkus_db_enabled: true
+keycloak_quarkus_metrics_enabled: true
+keycloak_quarkus_db_engine: mariadb
+keycloak_quarkus_db_user: "{{ keycloak_mariadb_user }}"
+keycloak_quarkus_db_pass: "{{ keycloak_mariadb_password }}"
+keycloak_quarkus_bootstrap_admin_password: "{{ lookup('community.hashi_vault.hashi_vault',
+  '{{ hashi_vault_path }}:keycloak_quarkus_bootstrap_admin_password',
+  token=lookup('env', 'VAULT_TOKEN'), url=secrets_url, errors='warn') | default('') }}"
+keycloak_quarkus_version: 26.2.0
+keycloak_quarkus_jdbc_engine: mariadb
+keycloak_quarkus_hostname: stg.id.almalinux.org
+keycloak_quarkus_health_check_url: http://localhost:{{ keycloak_quarkus_http_port }}/realms/master/.well-known/openid-configuration
+keycloak_quarkus_proxy_headers: xforwarded
+keycloak_quarkus_http_relative_path: /
+keycloak_quarkus_transaction_xa_enabled: false
+keycloak_quarkus_proxy_mode: edge
+keycloak_quarkus_java_opts: -Djgroups.external_addr={{ tailscale_address }} -Djgroups.bind.address={{ tailscale_address }}
+keycloak_quarkus_systemd_wait_for_port: false
+
+# run health checks against localhost since we are running a cluster
+keycloak_quarkus_dest: /opt/keycloak
+keycloak_quarkus_installdir: "{{ keycloak_quarkus_dest }}/keycloak-{{ keycloak_quarkus_version }}"
+keycloak_quarkus_home: "{{ keycloak_quarkus_installdir }}"
+keycloak_quarkus_config_dir: "{{ keycloak_quarkus_home }}/conf"
+# end health check URL config

--- a/hosts
+++ b/hosts
@@ -71,3 +71,19 @@ mqtt.almalinux.org
 
 [almalinux_repo]
 repo.almalinux.org ansible_host=170.249.210.186
+
+[keycloak_galera_nodes]
+keycloak01.id.almalinux.org
+keycloak02.id.almalinux.org
+keycloak03.id.almalinux.org
+
+[keycloak:children]
+keycloak_galera_nodes
+
+[keycloak_galera_nodes_stg]
+keycloak01.stg.id.almalinux.org ansible_host=3.216.78.167
+keycloak02.stg.id.almalinux.org ansible_host=44.205.6.79
+keycloak03.stg.id.almalinux.org ansible_host=54.237.151.67
+
+[keycloak_stg:children]
+keycloak_galera_nodes_stg

--- a/keycloak.yml
+++ b/keycloak.yml
@@ -1,0 +1,48 @@
+---
+- name: Check required vars and bootstrap var
+  hosts: localhost
+  tasks:
+    - name: Are we bootstrapping?
+      ansible.builtin.pause:
+        prompt: "Are you really trying to bootstrap the cluster?  Press enter to continue or Ctrl-C to exit"
+      when: keycloak_mariadb_galera_bootstrap is defined and keycloak_mariadb_galera_bootstrap
+
+    - name: Check if var is set - {{ item }}
+      ansible.builtin.assert:
+        that: "{{ lookup('env', item) | length > 0 }}"
+        fail_msg: "{{ item }} is not set"
+      loop:
+        - VAULT_TOKEN
+        - IPA_USER
+        - IPA_PASSWORD
+
+- name: Gather facts from all hosts in group
+  vars:
+    keycloak_host_group: keycloak
+  hosts: "{{ keycloak_host_group }}"
+  # fact gathering handled with an explicit task below
+  gather_facts: false
+  tasks:
+    - name: Gather facts # noqa run-once[task]
+      ansible.builtin.setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: true
+      loop: "{{ groups[keycloak_host_group] }}"
+      run_once: true
+
+- name: Configure keycloak servers
+  # all groups/hosts listed here will be part of the galera/keycloak cluster
+  # be careful if adding new hosts/groups that this is the desired outcome
+  vars:
+    keycloak_host_group: keycloak
+  hosts: "{{ keycloak_host_group }}"
+  gather_facts: false # Set to 'false' because the previous play should have populated facts.
+                      # Or set to 'true' only if you specifically need to refresh facts
+                      # for the hosts matching the --limit AFTER the above has run.
+  roles:
+    - common
+    - ipa_client
+    - keycloak
+    - community.zabbix.zabbix_agent
+    - devsec.hardening.os_hardening
+    - devsec.hardening.ssh_hardening

--- a/keycloak_stg.yml
+++ b/keycloak_stg.yml
@@ -1,0 +1,48 @@
+---
+- name: Check required vars and bootstrap var
+  hosts: localhost
+  tasks:
+    - name: Are we bootstrapping?
+      ansible.builtin.pause:
+        prompt: "Are you really trying to bootstrap the cluster?  Press enter to continue or Ctrl-C to exit"
+      when: keycloak_mariadb_galera_bootstrap is defined and keycloak_mariadb_galera_bootstrap
+
+    - name: Check if var is set - {{ item }}
+      ansible.builtin.assert:
+        that: "{{ lookup('env', item) | length > 0 }}"
+        fail_msg: "{{ item }} is not set"
+      loop:
+        - VAULT_TOKEN
+        - IPA_USER
+        - IPA_PASSWORD
+
+- name: Gather facts from all hosts in group
+  vars:
+    keycloak_host_group: keycloak_galera_nodes_stg
+  hosts: "{{ keycloak_host_group }}"
+  # fact gathering handled with an explicit task below
+  gather_facts: false
+  tasks:
+    - name: Gather facts # noqa run-once[task]
+      ansible.builtin.setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: true
+      loop: "{{ groups[keycloak_host_group] }}"
+      run_once: true
+
+- name: Configure keycloak servers
+  # all groups/hosts listed here will be part of the galera/keycloak cluster
+  # be careful if adding new hosts/groups that this is the desired outcome
+  vars:
+    keycloak_host_group: keycloak_galera_nodes_stg
+  hosts: "{{ keycloak_host_group }}"
+  gather_facts: false # Set to 'false' because the previous play should have populated facts.
+                      # Or set to 'true' only if you specifically need to refresh facts
+                      # for the hosts matching the --limit AFTER the above has run.
+  roles:
+    - common
+    - ipa_client
+    - keycloak
+    - community.zabbix.zabbix_agent
+    - devsec.hardening.os_hardening
+    - devsec.hardening.ssh_hardening

--- a/requirements.yml
+++ b/requirements.yml
@@ -9,6 +9,8 @@ collections:
     - name: community.zabbix
       version: ">=3.0.4"
     - name: community.general
+    - name: middleware_automation.keycloak
+      version: ">=3.0.1"
 
 roles:
     - name: artis3n.tailscale

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -1,0 +1,1 @@
+keycloak_certbot_ssl: false

--- a/roles/keycloak/handlers/main.yml
+++ b/roles/keycloak/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Restart caddy
+  ansible.builtin.service:
+    name: caddy
+    state: restarted

--- a/roles/keycloak/meta/main.yml
+++ b/roles/keycloak/meta/main.yml
@@ -1,0 +1,6 @@
+---
+dependencies:
+  - role: artis3n.tailscale
+
+collections:
+  - middleware_automation.keycloak

--- a/roles/keycloak/tasks/caddy.yml
+++ b/roles/keycloak/tasks/caddy.yml
@@ -1,0 +1,30 @@
+---
+- name: Install caddy copr repo
+  community.general.copr:
+    host: copr.fedorainfracloud.org
+    state: enabled
+    name: "@caddy/caddy"
+    chroot: epel-9-x86_64
+
+- name: Install caddy
+  ansible.builtin.package:
+    name: caddy
+    state: present
+
+- name: Enable caddy
+  ansible.builtin.service:
+    name: caddy
+    enabled: true
+
+- name: Certbot
+  ansible.builtin.include_tasks: certbot.yml
+  when: keycloak_certbot_ssl
+
+- name: Upload caddy config
+  ansible.builtin.template:
+    src: Caddyfile.j2
+    dest: /etc/caddy/Caddyfile
+    mode: '0700'
+    owner: caddy
+    group: caddy
+  notify: Restart caddy

--- a/roles/keycloak/tasks/certbot.yml
+++ b/roles/keycloak/tasks/certbot.yml
@@ -1,0 +1,34 @@
+---
+- name: Route 53 tasks
+  ansible.builtin.include_tasks: route53.yml
+
+- name: Install certbot and route53 plugin
+  ansible.builtin.package:
+    name:
+      - certbot
+      - python3-certbot-dns-route53
+    state: present
+  tags: certbot
+
+- name: Configure certbot deploy hook
+  ansible.builtin.template:
+    src: certbot-deploy-hook.sh.j2
+    dest: /etc/letsencrypt/deploy-caddy.sh
+    mode: "0755"
+  tags: certbot
+
+- name: Get certificate with certbot
+  args:
+    creates: /etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem
+  ansible.builtin.shell: >
+    certbot certonly --dns-route53 -d {{ inventory_hostname }} -d {{ keycloak_quarkus_hostname }} -m {{ certbot_email }} --agree-tos -n --force-renewal
+    --deploy-hook /etc/letsencrypt/deploy-caddy.sh
+  throttle: 1
+  tags: certbot skip_ansible_lint
+
+- name: Start/enable certbot renew timer
+  ansible.builtin.systemd_service:
+    name: certbot-renew.timer
+    enabled: true
+    state: started
+  tags: certbot

--- a/roles/keycloak/tasks/galera_bootstrap.yml
+++ b/roles/keycloak/tasks/galera_bootstrap.yml
@@ -1,0 +1,35 @@
+---
+- name: Bootstrap MariaDB Galera
+  containers.podman.podman_container:
+    name: mariadb
+    image: docker.io/bitnami/mariadb-galera:{{ keycloak_mariadb_version }}
+    state: started
+    network:
+      - podman_network
+    ports: "{{ keycloak_mariadb_galera_ports }}"
+    env:
+      MARIADB_GALERA_CLUSTER_BOOTSTRAP: true
+      MARIADB_ROOT_PASSWORD: "{{ keycloak_mariadb_galera_root_password }}"
+      MARIADB_USER: "{{ keycloak_mariadb_user }}"
+      MARIADB_PASSWORD: "{{ keycloak_mariadb_password }}"
+      MARIADB_DATABASE: "{{ keycloak_mariadb_database }}"
+      MARIADB_GALERA_MARIABACKUP_USER: "{{ keycloak_mariadb_galera_mariabackup_user }}"
+      MARIADB_GALERA_MARIABACKUP_PASSWORD: "{{ keycloak_mariadb_galera_mariabackup_password }}"
+      MARIADB_REPLICATION_USER: "{{ keycloak_mariadb_replication_user }}"
+      MARIADB_REPLICATION_PASSWORD: "{{ keycloak_mariadb_replication_password }}"
+      MARIADB_GALERA_CLUSTER_ADDRESS: gcomm://
+      MARIADB_EXTRA_FLAGS: --wsrep_provider_options=ist.recv_addr={{ tailscale_address }}:4568;ist.recv_bind=0.0.0.0:4568
+        --wsrep_node_incoming_address={{ tailscale_address }} --wsrep_sst_receive_address={{ tailscale_address }}
+    volumes:
+      - /opt/mariadb:/bitnami/mariadb
+  register: keycloak_galera_bootstrapped
+  run_once: true
+
+- name: Wait until mariadb is in sync to continue
+  ansible.builtin.command: mysql -h 127.0.0.1 --protocol=TCP --password={{ keycloak_mariadb_galera_root_password }}
+    -BNe 'SHOW GLOBAL STATUS LIKE "wsrep_local_state_comment"' --auto-vertical-output
+  register: mariadb_ready
+  retries: 60
+  delay: 10
+  until: ("Synced" in mariadb_ready.stdout)
+  changed_when: false

--- a/roles/keycloak/tasks/galera_common.yml
+++ b/roles/keycloak/tasks/galera_common.yml
@@ -1,0 +1,30 @@
+---
+- name: Install podman
+  ansible.builtin.package:
+    name: podman
+    state: present
+
+- name: Create a podman network
+  containers.podman.podman_network:
+    name: podman_network
+
+- name: Create persistent mariadb container directory
+  ansible.builtin.file:
+    path: /opt/mariadb
+    state: directory
+    owner: 1001
+    group: 1001
+    mode: '0700'
+  register: create_opt_mariadb
+
+- name: Set SELinux context for container's directory
+  community.general.sefcontext:
+    target: '/opt/mariadb(/.*)?'
+    setype: container_file_t
+    state: present
+  register: set_selinux_context
+
+# need to apply new contexts "now" to prevent potential issues in later tasks
+- name: Apply new SELinux file context to filesystem # noqa no-handler no-changed-when
+  ansible.builtin.command: restorecon -irv /opt/mariadb
+  when: set_selinux_context.changed or create_opt_mariadb.changed

--- a/roles/keycloak/tasks/galera_normal.yml
+++ b/roles/keycloak/tasks/galera_normal.yml
@@ -1,0 +1,29 @@
+- name: Setup mariadb galera master/master replicas
+  containers.podman.podman_container:
+    name: mariadb
+    image: docker.io/bitnami/mariadb-galera:{{ keycloak_mariadb_version }}
+    state: started
+    network:
+      - podman_network
+    ports: "{{ keycloak_mariadb_galera_ports }}"
+    env:
+      MARIADB_GALERA_CLUSTER_ADDRESS: gcomm://{% for ip in keycloak_cluster_ips %}{{ ip }}:4567{{ ',' if not loop.last }}{% endfor %}
+      MARIADB_GALERA_MARIABACKUP_USER: "{{ keycloak_mariadb_galera_mariabackup_user }}"
+      MARIADB_GALERA_MARIABACKUP_PASSWORD: "{{ keycloak_mariadb_galera_mariabackup_password }}"
+      MARIADB_REPLICATION_USER: "{{ keycloak_mariadb_replication_user }}"
+      MARIADB_REPLICATION_PASSWORD: "{{ keycloak_mariadb_replication_password }}"
+      MARIADB_EXTRA_FLAGS: --wsrep_provider_options=ist.recv_addr={{ tailscale_address }}:4568;ist.recv_bind=0.0.0.0:4568
+        --wsrep_node_incoming_address={{ tailscale_address }} --wsrep_sst_receive_address={{ tailscale_address }}
+    volumes:
+      - /opt/mariadb:/bitnami/mariadb
+  register: mariadb_setup
+
+- name: Wait until mariadb is in sync to continue # noqa no-handler
+  ansible.builtin.command: mysql -h 127.0.0.1 --protocol=TCP --password={{ keycloak_mariadb_galera_root_password }}
+    -BNe 'SHOW GLOBAL STATUS LIKE "wsrep_local_state_comment"' --auto-vertical-output
+  register: mariadb_ready
+  retries: 60
+  delay: 10
+  until: ("Synced" in mariadb_ready.stdout)
+  changed_when: false
+  when: mariadb_setup.changed

--- a/roles/keycloak/tasks/keycloak.yml
+++ b/roles/keycloak/tasks/keycloak.yml
@@ -1,0 +1,37 @@
+---
+- name: Create keycloak config dir
+  ansible.builtin.file:
+    path: /etc/keycloak
+    state: directory
+    mode: "0700"
+
+- name: Include middleware automation keycloak role
+  ansible.builtin.include_role:
+    name: middleware_automation.keycloak.keycloak_quarkus
+
+- name: Clone almalinux theme from git
+  ansible.builtin.git:
+    repo: git@github.com:AlmaLinux/almalinux-keycloak-theme.git
+    dest: tmp/almalinux-keycloak-theme
+    single_branch: yes
+    version: main
+    force: true
+  delegate_to: localhost
+  run_once: true
+
+- name: Copy almalinux theme
+  ansible.posix.synchronize:
+    src: tmp/almalinux-keycloak-theme/themes/almalinux
+    dest: /opt/keycloak/keycloak-{{ keycloak_quarkus_version }}/themes/
+    delete: true
+    rsync_opts:
+      - "--chown keycloak:keycloak"
+      - "--exclude .git"
+  register: keycloak_theme_updated
+
+# can't use a handler, we need to do this one at a time
+- name: Restart keycloak
+  ansible.builtin.include_role:
+    name: middleware_automation.keycloak.keycloak_quarkus
+    tasks_from: restart/serial
+  when: keycloak_theme_updated

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -1,0 +1,67 @@
+---
+- name: Pick bootstrap host
+  ansible.builtin.set_fact:
+    keycloak_mariadb_galera_bootstrap_host: "{{ inventory_hostname }}"
+  when: keycloak_mariadb_galera_bootstrap is defined and keycloak_mariadb_galera_bootstrap
+  run_once: true
+
+- name: Check that all nodes have tailscale IPs so we don't nuke the cluster with a bad IP list
+  ansible.builtin.assert:
+    that: hostvars[item]['tailscale_node_ipv4'] is defined or hostvars[item]['ansible_tailscale0']['ipv4']['address'] is defined
+    fail_msg: "interface tailscale 0 does not exist, or does not have an IP"
+  delegate_to: localhost
+  delegate_facts: true
+  loop: "{{ groups[keycloak_host_group] }}"
+  run_once: true
+
+- name: Set local tailscale address
+  ansible.builtin.set_fact:
+    tailscale_address: "{{ tailscale_node_ipv4 | default(ansible_tailscale0['ipv4']['address']) }}"
+
+- name: Build internal IP list for cluster comms
+  vars:
+    ip: "{{ hostvars[item]['tailscale_node_ipv4'] | default(hostvars[item]['ansible_tailscale0']['ipv4']['address']) }}"
+  ansible.builtin.set_fact:
+    keycloak_cluster_ips: "{{ keycloak_cluster_ips | default([]) + [ip] }}"
+  loop: "{{ groups[keycloak_host_group] }}"
+  delegate_to: localhost
+  run_once: true
+
+- name: Set jgroup IP for keycloak
+  ansible.builtin.set_fact:
+    keycloak_quarkus_jgroups_ip: "{{ hostvars[item]['tailscale_node_ipv4'] | default(hostvars[item]['ansible_tailscale0']['ipv4']['address']) }}"
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  loop: "{{ groups[keycloak_host_group] }}"
+
+- name: Remove old openjdk version(s)
+  ansible.builtin.package:
+    name:
+      - java-11-openjdk-headless
+      - java-17-openjdk-headless
+    state: absent
+
+- name: Install mariadb client
+  ansible.builtin.package:
+    name: mariadb
+    state: present
+
+- name: Configure Caddy reverse proxy
+  ansible.builtin.include_tasks: caddy.yml
+
+- name: Configure MariaDB Galera cluster
+  ansible.builtin.include_tasks: galera.yml
+
+# # there is no difference between the following two tasks other than the run_once when bootstrapping
+# # this is because the start keycloak task operates too fast when bootstrapping and leads to deadlocks on a fresh database
+# # this is of no concern in normal production
+# - name: Configure Keycloak cluster (bootstrap)
+#   ansible.builtin.include_tasks: keycloak.yml
+#   run_once: true
+#   when: keycloak_mariadb_galera_bootstrap is defined and keycloak_mariadb_galera_bootstrap
+#     and inventory_hostname == keycloak_mariadb_galera_bootstrap_host
+
+- name: Configure Keycloak cluster (normal, already bootstrapped)
+  ansible.builtin.include_tasks: keycloak.yml
+  # when: ((keycloak_mariadb_galera_bootstrap_host is defined and keycloak_mariadb_galera_bootstrap_host != inventory_hostname)
+  #   or keycloak_mariadb_galera_bootstrap_host is not defined)

--- a/roles/keycloak/tasks/route53.yml
+++ b/roles/keycloak/tasks/route53.yml
@@ -1,0 +1,21 @@
+---
+- name: Create AWS config dir
+  ansible.builtin.file:
+    path: /root/.aws
+    state: directory
+    mode: "0700"
+
+- name: Write AWS config file
+  vars:
+    aws_access_key_id:
+      "{{ lookup('community.hashi_vault.hashi_vault',
+      'kv/data/infra/{% if staging %}stg/{% endif %}aws/{{ keycloak_quarkus_hostname }}/route53:access_key',
+      token=lookup('env', 'VAULT_TOKEN'), url=secrets_url) }}"
+    aws_secret_access_key:
+      "{{ lookup('community.hashi_vault.hashi_vault',
+      'kv/data/infra/{% if staging %}stg/{% endif %}aws/{{ keycloak_quarkus_hostname }}/route53:secret_key',
+      token=lookup('env', 'VAULT_TOKEN'), url=secrets_url) }}"
+  ansible.builtin.template:
+    src: aws_config.j2
+    dest: /root/.aws/config
+    mode: "0600"

--- a/roles/keycloak/templates/Caddyfile.j2
+++ b/roles/keycloak/templates/Caddyfile.j2
@@ -1,0 +1,37 @@
+# {{ ansible_managed }}
+# The Caddyfile is an easy way to configure your Caddy web server.
+#
+# Unless the file starts with a global options block, the first
+# uncommented line is always the address of your site.
+#
+# To use your own domain name (with automatic HTTPS), first make
+# sure your domain's A/AAAA DNS records are properly pointed to
+# this machine's public IP, then replace ":80" below with your
+# domain name.
+
+{{ inventory_hostname }} {{ keycloak_quarkus_hostname }} {
+    @protected {
+        path_regexp ^/($|admin|welcome|metrics|health).*$
+    }
+
+    @allowedIPs {
+        remote_ip 100.64.0.0/10
+    }
+
+    handle @protected {
+        handle @allowedIPs {
+            reverse_proxy localhost:8080
+        }
+        respond "Access denied" 403
+    }
+
+    handle {
+        reverse_proxy localhost:8080
+    }
+
+    {% if keycloak_certbot_ssl %}tls /etc/caddy/{{ inventory_hostname }}.fullchain.pem /etc/caddy/{{ inventory_hostname}}.privkey.pem{% endif %}
+    
+}
+
+# Refer to the Caddy docs for more information:
+# https://caddyserver.com/docs/caddyfile

--- a/roles/keycloak/templates/aws_config.j2
+++ b/roles/keycloak/templates/aws_config.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+[default]
+region = us-east-1
+aws_access_key_id = {{ aws_access_key_id }}
+aws_secret_access_key = {{ aws_secret_access_key}}

--- a/roles/keycloak/templates/certbot-deploy-hook.sh.j2
+++ b/roles/keycloak/templates/certbot-deploy-hook.sh.j2
@@ -1,0 +1,11 @@
+#!/bin/sh
+# {{ ansible_managed }}
+
+# dynamic based on domain. ex: /etc/letsencrypt/live/example.com
+cert_dir=$RENEWED_LINEAGE
+
+install -pD -m 700 -g caddy -o caddy $cert_dir/fullchain.pem /etc/caddy/{{ inventory_hostname }}.fullchain.pem
+install -pD -m 700 -g caddy -o caddy $cert_dir/privkey.pem /etc/caddy/{{ inventory_hostname }}.privkey.pem
+
+# only reload caddy if it is running
+systemctl is-active --quiet caddy.service && systemctl reload caddy.service


### PR DESCRIPTION
Configures keycloak as well as a master/master MariaDB Galera cluster as the DB backend and configures functional session cache clustering for keycloak.

hosts file is still a draft as current production keycloak servers are not ready to be rebuilt with this yet - a maintenance window will need to be scheduled.

Requires the changes from https://github.com/ansible-middleware/keycloak/pull/281 to work properly.