### PR TITLE
Add prometheus role

### DIFF
--- a/group_vars/prometheus.yml
+++ b/group_vars/prometheus.yml
@@ -1,0 +1,9 @@
+---
+# Caddy needs 80/443 open for the web UI + automatic HTTPS (ACME).
+# 9090 is only opened in dev mode, for a remote Grafana to scrape directly.
+firewalld_extra_allow_ports: "{{ ['80/tcp', '443/tcp'] + (['9090/tcp'] if prometheus_dev_mode | bool else []) }}"
+
+# bcrypt hash for the Prometheus web UI basic auth (generate with `caddy hash-password`).
+prometheus_basicauth_hash:
+  "{{ lookup('community.hashi_vault.hashi_vault', 'kv/data/infra/prometheus:basicauth_hash',
+  token=lookup('env', 'VAULT_TOKEN'), url=secrets_url) }}"

--- a/host_vars/prometheus.almalinux.org.yml
+++ b/host_vars/prometheus.almalinux.org.yml
@@ -1,0 +1,5 @@
+---
+# Dev host: no public DNS for this name, and a remote Grafana scrapes :9090
+# directly. Exposes Prometheus on 0.0.0.0:9090 (firewall opened) and switches
+# Caddy to its internal CA so 443 serves a (self-signed) cert.
+prometheus_dev_mode: true

--- a/hosts
+++ b/hosts
@@ -107,3 +107,6 @@ astra.almalinux.org
 
 [people]
 almapeople.org
+
+[prometheus]
+prometheus.almalinux.org

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,10 @@
+---
+- name: Configure Prometheus
+  hosts: prometheus
+  become: true
+  roles:
+    - common
+    - prometheus
+    - community.zabbix.zabbix_agent
+    - devsec.hardening.os_hardening
+    - devsec.hardening.ssh_hardening

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -2,6 +2,8 @@
 # Upstream release from https://prometheus.io/download/ (GitHub release tarball).
 prometheus_version: 3.5.0
 prometheus_arch: amd64
+prometheus_tarball: "prometheus-{{ prometheus_version }}.linux-{{ prometheus_arch }}.tar.gz"
+prometheus_download_url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/{{ prometheus_tarball }}"
 
 prometheus_user: prometheus
 prometheus_group: prometheus

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -1,0 +1,48 @@
+---
+# Upstream release from https://prometheus.io/download/ (GitHub release tarball).
+prometheus_version: 3.5.0
+prometheus_arch: amd64
+
+prometheus_user: prometheus
+prometheus_group: prometheus
+
+prometheus_install_dir: /opt/prometheus
+prometheus_config_dir: /etc/prometheus
+prometheus_data_dir: /var/lib/prometheus
+
+# Deployment mode.
+#  Production (default): Prometheus binds to localhost and is reachable only
+#    through Caddy on 443 with a real (Let's Encrypt) certificate. Requires the
+#    inventory hostname to resolve publicly to this host.
+#  Dev (prometheus_dev_mode: true): additionally exposes Prometheus directly on
+#    :9090 (binds 0.0.0.0 + opens the firewall port) so a remote Grafana can
+#    scrape without DNS, and Caddy uses its internal CA so 443 works without a
+#    public A record (self-signed — clients must skip verification).
+prometheus_dev_mode: false
+
+# Caddy always proxies to Prometheus via 127.0.0.1; dev mode also binds 0.0.0.0.
+prometheus_listen_address: "{{ '0.0.0.0' if prometheus_dev_mode | bool else '127.0.0.1' }}"
+prometheus_listen_port: 9090
+prometheus_external_url: "https://{{ inventory_hostname }}"
+
+# How long to keep samples on disk.
+prometheus_retention_time: 30d
+
+# Global scrape settings.
+prometheus_scrape_interval: 30s
+prometheus_evaluation_interval: 30s
+
+# Scrape jobs. The build.almalinux.org/metrics endpoint is the default target.
+prometheus_scrape_configs:
+  - job_name: almalinux-build
+    scheme: https
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - build.almalinux.org
+
+# Front the web UI with Caddy (automatic HTTPS) + HTTP basic auth.
+prometheus_caddy_enabled: true
+# bcrypt hash from `caddy hash-password`; set in host_vars (typically a Vault lookup).
+prometheus_basicauth_user: admin
+prometheus_basicauth_hash: ''

--- a/roles/prometheus/handlers/main.yml
+++ b/roles/prometheus/handlers/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+
+- name: Restart prometheus
+  ansible.builtin.systemd_service:
+    name: prometheus
+    state: restarted
+
+- name: Reload prometheus
+  ansible.builtin.systemd_service:
+    name: prometheus
+    state: reloaded
+
+- name: Restart caddy
+  ansible.builtin.systemd_service:
+    name: caddy.service
+    state: restarted

--- a/roles/prometheus/tasks/caddy.yml
+++ b/roles/prometheus/tasks/caddy.yml
@@ -1,0 +1,36 @@
+---
+- name: Install Caddy
+  ansible.builtin.dnf:
+    name: caddy
+    state: present
+  tags:
+    - caddy
+
+- name: Create Caddy log dir
+  ansible.builtin.file:
+    path: /var/log/caddy/
+    owner: caddy
+    group: caddy
+    mode: "0700"
+    state: directory
+  tags:
+    - caddy
+
+- name: Distribute /etc/caddy/Caddyfile
+  ansible.builtin.template:
+    src: Caddyfile.j2
+    dest: /etc/caddy/Caddyfile
+    mode: "0600"
+    owner: caddy
+    group: caddy
+  notify: Restart caddy
+  tags:
+    - caddy
+
+- name: Start and enable Caddy
+  ansible.builtin.systemd_service:
+    name: caddy.service
+    state: started
+    enabled: true
+  tags:
+    - caddy

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -1,0 +1,98 @@
+---
+- name: Create prometheus group
+  ansible.builtin.group:
+    name: "{{ prometheus_group }}"
+    system: true
+
+- name: Create prometheus system user
+  ansible.builtin.user:
+    name: "{{ prometheus_user }}"
+    group: "{{ prometheus_group }}"
+    system: true
+    create_home: false
+    shell: /usr/sbin/nologin
+    home: "{{ prometheus_install_dir }}"
+
+- name: Download prometheus tarball
+  ansible.builtin.get_url:
+    url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ prometheus_arch }}.tar.gz"
+    dest: "/var/cache/prometheus-{{ prometheus_version }}.linux-{{ prometheus_arch }}.tar.gz"
+    mode: "0644"
+
+- name: Create prometheus install dir
+  ansible.builtin.file:
+    path: "{{ prometheus_install_dir }}"
+    state: directory
+    owner: "{{ prometheus_user }}"
+    group: "{{ prometheus_group }}"
+    mode: "0755"
+
+- name: Extract prometheus tarball
+  ansible.builtin.unarchive:
+    src: "/var/cache/prometheus-{{ prometheus_version }}.linux-{{ prometheus_arch }}.tar.gz"
+    dest: "{{ prometheus_install_dir }}"
+    remote_src: true
+    owner: "{{ prometheus_user }}"
+    group: "{{ prometheus_group }}"
+    extra_opts:
+      - "--strip-components=1"
+    creates: "{{ prometheus_install_dir }}/prometheus"
+  notify: Restart prometheus
+
+- name: Set SELinux context for prometheus binaries
+  community.general.sefcontext:
+    target: "{{ prometheus_install_dir }}/(prometheus|promtool)"
+    setype: bin_t
+    state: present
+  register: prometheus_sefcontext
+
+- name: Apply SELinux context to prometheus binaries # noqa no-handler no-changed-when
+  ansible.builtin.command: restorecon -irv {{ prometheus_install_dir }}
+  when: prometheus_sefcontext.changed
+
+- name: Create prometheus config dir
+  ansible.builtin.file:
+    path: "{{ prometheus_config_dir }}"
+    state: directory
+    owner: root
+    group: "{{ prometheus_group }}"
+    mode: "0750"
+
+- name: Create prometheus data dir
+  ansible.builtin.file:
+    path: "{{ prometheus_data_dir }}"
+    state: directory
+    owner: "{{ prometheus_user }}"
+    group: "{{ prometheus_group }}"
+    mode: "0750"
+
+- name: Write prometheus config
+  ansible.builtin.template:
+    src: prometheus.yml.j2
+    dest: "{{ prometheus_config_dir }}/prometheus.yml"
+    owner: root
+    group: "{{ prometheus_group }}"
+    mode: "0640"
+    validate: "{{ prometheus_install_dir }}/promtool check config %s"
+  notify: Reload prometheus
+
+- name: Install prometheus systemd unit
+  ansible.builtin.template:
+    src: prometheus.service.j2
+    dest: /etc/systemd/system/prometheus.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Reload systemd
+    - Restart prometheus
+
+- name: Enable and start prometheus
+  ansible.builtin.systemd_service:
+    name: prometheus
+    state: started
+    enabled: true
+
+- name: Caddy
+  ansible.builtin.include_tasks: caddy.yml
+  when: prometheus_caddy_enabled

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -15,8 +15,8 @@
 
 - name: Download prometheus tarball
   ansible.builtin.get_url:
-    url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ prometheus_arch }}.tar.gz"
-    dest: "/var/cache/prometheus-{{ prometheus_version }}.linux-{{ prometheus_arch }}.tar.gz"
+    url: "{{ prometheus_download_url }}"
+    dest: "/var/cache/{{ prometheus_tarball }}"
     mode: "0644"
 
 - name: Create prometheus install dir
@@ -29,7 +29,7 @@
 
 - name: Extract prometheus tarball
   ansible.builtin.unarchive:
-    src: "/var/cache/prometheus-{{ prometheus_version }}.linux-{{ prometheus_arch }}.tar.gz"
+    src: "/var/cache/{{ prometheus_tarball }}"
     dest: "{{ prometheus_install_dir }}"
     remote_src: true
     owner: "{{ prometheus_user }}"

--- a/roles/prometheus/templates/Caddyfile.j2
+++ b/roles/prometheus/templates/Caddyfile.j2
@@ -1,0 +1,24 @@
+# {{ ansible_managed }}
+
+{{ inventory_hostname }} {
+
+    reverse_proxy 127.0.0.1:{{ prometheus_listen_port }}
+
+{% if prometheus_dev_mode | bool %}
+    # Dev host without public DNS: use Caddy's internal CA (self-signed).
+    tls internal
+{% endif %}
+
+{% if prometheus_basicauth_hash | length > 0 %}
+    basic_auth {
+        {{ prometheus_basicauth_user }} {{ prometheus_basicauth_hash }}
+    }
+{% endif %}
+
+    log {
+        output file /var/log/caddy/{{ inventory_hostname }}.access.log {
+            roll_keep_for 30d
+        }
+    }
+
+}

--- a/roles/prometheus/templates/prometheus.service.j2
+++ b/roles/prometheus/templates/prometheus.service.j2
@@ -1,0 +1,25 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Prometheus
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# Prometheus does not implement sd_notify; Type=notify would time out on start.
+Type=simple
+User={{ prometheus_user }}
+Group={{ prometheus_group }}
+ExecStart={{ prometheus_install_dir }}/prometheus \
+    --config.file={{ prometheus_config_dir }}/prometheus.yml \
+    --storage.tsdb.path={{ prometheus_data_dir }} \
+    --storage.tsdb.retention.time={{ prometheus_retention_time }} \
+    --web.listen-address={{ prometheus_listen_address }}:{{ prometheus_listen_port }} \
+    --web.external-url={{ prometheus_external_url }} \
+    --web.enable-lifecycle
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+RestartSec=10
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/prometheus/templates/prometheus.yml.j2
+++ b/roles/prometheus/templates/prometheus.yml.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+global:
+  scrape_interval: {{ prometheus_scrape_interval }}
+  evaluation_interval: {{ prometheus_evaluation_interval }}
+
+scrape_configs:
+{{ prometheus_scrape_configs | to_nice_yaml(indent=2) | indent(2, true) }}


### PR DESCRIPTION
Install Prometheus from the upstream release tarball and scrape build.almalinux.org/metrics. Fronted by Caddy on 443 with basic auth; Prometheus binds to localhost by default.

prometheus_dev_mode (off by default) exposes Prometheus directly on :9090 and switches Caddy to its internal CA for dev hosts without public DNS. Enabled for prometheus.almalinux.org via host_vars.